### PR TITLE
grant iam.serviceAccounts.actAs permission

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -17,7 +17,7 @@ locals {
     "roles/serviceusage.serviceUsageViewer", # To allow GitHub Actions to list services `serviceusage.services.list`
     "roles/iam.workloadIdentityPoolViewer",  # To allow GitHub Actions to use Workload Identity `iam.workloadIdentityPools.get`
     # "roles/iam.workloadIdentityUser",        # To allow GitHub Actions to use Workload Identity
-    "roles/iam.serviceAccountAdmin", # To manage other service account
+    "roles/iam.serviceAccountAdmin",         # To manage other service account
     "roles/iam.serviceAccountUser",          # To allow github-actions sa to deploy cloud run (with specified sa) (`iam.serviceAccounts.actAs`)
     "roles/resourcemanager.projectIamAdmin", # GitHub Actions identity
     "roles/run.developer",                   # To allow GitHub Actions to deploy to Cloud Run

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -18,7 +18,7 @@ locals {
     "roles/iam.workloadIdentityPoolViewer",  # To allow GitHub Actions to use Workload Identity `iam.workloadIdentityPools.get`
     # "roles/iam.workloadIdentityUser",        # To allow GitHub Actions to use Workload Identity
     "roles/iam.serviceAccountAdmin", # To manage other service account
-    # "roles/iam.serviceAccountUser",          # To allow github-actions sa to deploy cloud run (with specified sa)
+    "roles/iam.serviceAccountUser",          # To allow github-actions sa to deploy cloud run (with specified sa) (`iam.serviceAccounts.actAs`)
     "roles/resourcemanager.projectIamAdmin", # GitHub Actions identity
     "roles/run.developer",                   # To allow GitHub Actions to deploy to Cloud Run
     # "roles/run.admin",                       # to grant run.invoker (Permission 'run.services.setIamPolicy' is necessary)


### PR DESCRIPTION
# why

`Error 403: Permission 'iam.serviceaccounts.actAs' denied on service account cloud-run-app-sample@cloud-run-template-naka.iam.gserviceaccount.com`

# what

add `"roles/iam.serviceAccountUser`